### PR TITLE
Adding ggpo attribution in readme

### DIFF
--- a/Plugins/GGPOUE4/README.md
+++ b/Plugins/GGPOUE4/README.md
@@ -1,6 +1,6 @@
 # GGPOUE4
 
-A port of [GGPO](http://ggpo.net) to an Unreal Engine 4 plugin. This was branched from BwdYeti's great initial work on this repo [here](https://github.com/BwdYeti/GGPOUE4).
+A port of [GGPO](http://ggpo.net) to an Unreal Engine 4 plugin. This was branched from ErebusWolf's ggpo repo with network abstraction [here](https://github.com/erebuswolf/ggpo-Unreal-Plugin-with-Network-Abstraction), which was in turn branched from BwdYeti's great initial work on this repo [here](https://github.com/BwdYeti/GGPOUE4).
 
 ## Setup & Usage
 


### PR DESCRIPTION
Adding attribution to the source of the ggpo plugin code in the readme. I had discussed having the plugin be a sub repo with you so that it would be easy to pull back changes but that was years ago now. I'm assuming you have been busy with other things. I just want people to be able to trace back the source of the code for this plugin as your repo history ends where it was copied from the previous repo.