### PR TITLE
Allow non-zero minimum numbers in RNG

### DIFF
--- a/Source/NightSkyEngine/Battle/Actors/BattleObject.cpp
+++ b/Source/NightSkyEngine/Battle/Actors/BattleObject.cpp
@@ -2739,7 +2739,7 @@ int32 ABattleObject::GenerateRandomNumber(int32 Min, int32 Max)
 		Min = Temp;
 	}
 	int32 Result = FRandomManager::GenerateRandomNumber();
-	Result = Result % (Max - Min + 1);
+	Result = (Result % (Max - Min + 1)) + Min;
 	return Result;
 }
 


### PR DESCRIPTION
The current function only generates numbers in a range from 0 to the difference of `Max` and `Min`, which doesn't allow negative numbers or ranges that do not start from 0. (i.e. 10000-15000, which would only generate numbers between 0-5000)