### PR TITLE
fixed crash when p2 team is larger than p1 team

### DIFF
--- a/Plugins/NightSkyEngine/Source/NightSkyEngine/Battle/NightSkyGameState.cpp
+++ b/Plugins/NightSkyEngine/Source/NightSkyEngine/Battle/NightSkyGameState.cpp
@@ -356,7 +356,7 @@ void ANightSkyGameState::MatchInit()
 	for (int i = 0; i < Players.Num(); i++)
 	{
 		Players[i]->PlayerIndex = i >= BattleState.TeamData[0].TeamCount;
-		Players[i]->TeamIndex = i >= BattleState.TeamData[0].TeamCount ? i - BattleState.TeamData[0].TeamCount : i;
+		Players[i]->TeamIndex = i >= BattleState.TeamData[0].TeamCount ? 0 : 1;
 		Players[i]->PlayerFlags &= ~PLF_IsOnScreen;
 		Players[i]->ObjNumber = i + MaxBattleObjects;
 		Players[i]->CallSubroutine(Subroutine_Cmn_MatchInit);
@@ -1708,7 +1708,7 @@ TArray<APlayerObject*> ANightSkyGameState::GetTeam(bool IsP1) const
 		return PlayerObjects;
 	}
 	TArray<APlayerObject*> PlayerObjects;
-	for (int i = BattleState.TeamData[1].TeamCount; i < Players.Num(); i++)
+	for (int i = BattleState.TeamData[0].TeamCount; i < Players.Num(); i++)
 	{
 		PlayerObjects.Add(Players[i]);
 		for (int j = 0; j < PlayerObjects.Num() - 1; j++)


### PR DESCRIPTION
I'm not sure if the engine is meant to support lopsided teams, but right now unreal will crash from an array out of bounds exceptions if the p1 and p2 team counts are not the same.

You can test this by giving the p1 player list 1 player object and the p2 player list 2 player objects.

## ANightSkyGameState::MatchInit() **line 359**
this line doesn't work for all team sizes. If p1 teamcount is 1 and p2 teamcount is 2 the first player in team 2 will get a team index of 0 instead of 1

##### **example for i =1, and BattleState.TeamData[0].TeamCount = 1**:
* ######   Players[i]->TeamIndex =  i >= BattleState.TeamData[0].TeamCount ? i - BattleState.TeamData[0].TeamCount : i
* ######   Players[1]->TeamIndex =  1 >= 1 ? 1 - 1 : 1
* ######   Players[1]->TeamIndex =  0


## ANightSkyGameState::GetTeam() **line 1711**
there's a typo here. When getting the p2 team this for loop starts indexing after the amount of players in team 2 instead of team 1. So this only works when team counts are equal.